### PR TITLE
v1.2.1 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v1.2.0
+# v1.2.1
 
-- bump `Microsoft.AspNetCore.Components` to `3.1.0`
-- bump `Microsoft.AspNetCore.Components.Web` to `3.1.0`
+- bump `Microsoft.AspNetCore.Components` to `3.1.1`
+- bump `Microsoft.AspNetCore.Components.Web` to `3.1.1`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "currietechnologies-razorclipboard",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A Razor Class Library for interacting with the browser clipboard",
   "scripts": {
     "build": "SET NODE_ENV=production && webpack -p --color",


### PR DESCRIPTION
# v1.2.1

- bump `Microsoft.AspNetCore.Components` to `3.1.1`
- bump `Microsoft.AspNetCore.Components.Web` to `3.1.1`
