### PR TITLE
Release/v1.2.3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
 
-* text=auto
+* text=auto eol=lf
 
 *.sh eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v1.2.2
+# v1.2.3
 
-- bump `Microsoft.AspNetCore.Components` to `3.1.3`
-- bump `Microsoft.AspNetCore.Components.Web` to `3.1.3`
+- bump `Microsoft.AspNetCore.Components` to `3.1.4`
+- bump `Microsoft.AspNetCore.Components.Web` to `3.1.4`

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This package provides Blazor applications with access to the browser's [Clipboar
 
 | Chrome | Edge Legacy | Edge (Chromium) | Firefox |  IE   | Opera  | Safari |
 | :----: | :---------: | :-------------: | :-----: | :---: | :----: | :----: |
-| ✔️ 63+ |      ❌      |       ✔️        |   ❌\*   |   ❌   | ✔️ 53+ |   ❔    |
+| ✔️ 63+ |      ❌      |       ✔️        |   ❌\*   |   ❌   | ✔️ 53+ |   ✔️    |
 
 _\* Firefox does support the clipboard API, but in a very restricted way that Blazor doesn't support._
 
@@ -64,4 +64,5 @@ The Clipboard API is a relatively new API and presents some security concerns, s
 ### References
 
 [Unblocking Clipboard Access](https://developers.google.com/web/updates/2018/03/clipboardapi)
+
 [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "currietechnologies-razorclipboard",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "A Razor Class Library for interacting with the browser clipboard",
   "scripts": {
     "build": "SET NODE_ENV=production && webpack -p --color",


### PR DESCRIPTION
# v1.2.3

- bump `Microsoft.AspNetCore.Components` to `3.1.4`
- bump `Microsoft.AspNetCore.Components.Web` to `3.1.4`
