### PR TITLE
Feature/safari support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This package provides Blazor applications with access to the browser's [Clipboar
 
 | Chrome | Edge Legacy | Edge (Chromium) | Firefox |  IE   | Opera  | Safari |
 | :----: | :---------: | :-------------: | :-----: | :---: | :----: | :----: |
-| ✔️ 63+ |      ❌      |       ✔️        |   ❌\*   |   ❌   | ✔️ 53+ |   ✔️    |
+| ✔️ 63+ |      ❌      |       ✔️        |   ❌\*   |   ❌   | ✔️ 53+ |   ✔️ 13.1+   |
 
 _\* Firefox does support the clipboard API, but in a very restricted way that Blazor doesn't support._
 

--- a/package.json
+++ b/package.json
@@ -31,10 +31,13 @@
   },
   "browserslist": [
     "chrome 66",
+    "edge 79",
     "firefox 63",
     "opera 53",
-    "and_chr 76",
-    "and_ff 68",
+    "safari 13.1",
+    "and_chr 66",
+    "and_ff 63",
+    "ios_saf 13.4",
     "samsung 9.2"
   ],
   "author": "Michael J. Currie"


### PR DESCRIPTION
Update browserslist to include safari 13.1 with newly added clipboard support